### PR TITLE
fix offset not showing in the "edit type" dialog on more recent IDA versions

### DIFF
--- a/theme/dp701-extra-large/theme.css
+++ b/theme/dp701-extra-large/theme.css
@@ -677,12 +677,12 @@ TextEdit {
 	property-number-weight: 0;
 	property-number-italic: 0;
 }
-TextEdit QWidget {
+text_area_t QWidget {
 	background-color: transparent;
 }
 
 /* struct edit */
-TextEdit text_edit_margin_widget_t {
+text_area_t text_edit_margin_widget_t {
 	qproperty-header-color: #f1f1f1;
 	color: #666;
 }

--- a/theme/dp701-large/theme.css
+++ b/theme/dp701-large/theme.css
@@ -677,12 +677,12 @@ TextEdit {
 	property-number-weight: 0;
 	property-number-italic: 0;
 }
-TextEdit QWidget {
+text_area_t QWidget {
 	background-color: transparent;
 }
 
 /* struct edit */
-TextEdit text_edit_margin_widget_t {
+text_area_t text_edit_margin_widget_t {
 	qproperty-header-color: #f1f1f1;
 	color: #666;
 }

--- a/theme/dp701-medium/theme.css
+++ b/theme/dp701-medium/theme.css
@@ -677,12 +677,12 @@ TextEdit {
 	property-number-weight: 0;
 	property-number-italic: 0;
 }
-TextEdit QWidget {
+text_area_t QWidget {
 	background-color: transparent;
 }
 
 /* struct edit */
-TextEdit text_edit_margin_widget_t {
+text_area_t text_edit_margin_widget_t {
 	qproperty-header-color: #f1f1f1;
 	color: #666;
 }

--- a/theme/dp701-small/theme.css
+++ b/theme/dp701-small/theme.css
@@ -677,12 +677,12 @@ TextEdit {
 	property-number-weight: 0;
 	property-number-italic: 0;
 }
-TextEdit QWidget {
+text_area_t QWidget {
 	background-color: transparent;
 }
 
 /* struct edit */
-TextEdit text_edit_margin_widget_t {
+text_area_t text_edit_margin_widget_t {
 	qproperty-header-color: #f1f1f1;
 	color: #666;
 }


### PR DESCRIPTION
In more recent versions of IDA the addition of the "Size" column seems to have slightly broken the offset column.

Without fix:
![image](https://user-images.githubusercontent.com/5844066/210631287-5c50e9f1-f65b-4890-b1e3-d23d92a11a34.png)

With fix:
![image](https://user-images.githubusercontent.com/5844066/210631434-59a6e182-10f7-46d4-a1c9-4d7dd5eb941c.png)

Verified in IDA Free 8.2.